### PR TITLE
feat: abrir PDF desde URL en filtro de búsqueda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+target/


### PR DESCRIPTION
Se agregó la funcionalidad para abrir directamente un PDF desde la URL obtenida en el filtro de búsqueda de estudiantes.

Se modificó ConsultaEstudiante.java para capturar la URL y abrir el archivo con un solo clic.
Se agregó .gitignore para ignorar la carpeta target/.